### PR TITLE
Change audio player design for supporting mobile device

### DIFF
--- a/src/components/audio-player.js
+++ b/src/components/audio-player.js
@@ -23,15 +23,20 @@ class AudioPlayer extends React.Component {
         <div>
           <Player src={this.props.src} />
           <div className={styles.controls}>
-            <PlayPause className={styles.control} />
-            <CurrentTime className={`${styles.control} ${styles.currentTime}`} />
+            <div className={styles.controlGroup}>
+              <PlayPause className={styles.control} />
+              <CurrentTime className={`${styles.control} ${styles.currentTime}`} />
+              <span>/</span>
+              <Duration className={styles.control} />
+            </div>
             <div className={`${styles.controlGroup} ${styles.controlGroupSeek}`}>
               <Progress className={`${styles.control} ${styles.progress}`} />
               <SeekBar className={`${styles.control} ${styles.seekbar}`} />
             </div>
-            <Duration className={styles.control} />
-            <MuteUnmute className={styles.control} />
-            <Volume className={`${styles.control} ${styles.volume}`} />
+            <div className={`${styles.controlGroupVolume} ${styles.controlGroup}`}>
+              <MuteUnmute className={styles.control} />
+              <Volume className={`${styles.control} ${styles.volume}`} />
+            </div>
           </div>
         </div>
       </Media>

--- a/src/components/audio-player.module.scss
+++ b/src/components/audio-player.module.scss
@@ -1,10 +1,11 @@
 @import "./range-mixins.scss";
 
 .controls {
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(202px, 1fr)) 181px;
   align-items: center;
-  padding: 12px;
-  margin: 40px 0;
+  padding: 6px;
+  margin: 30px 0;
   background-color: #282F31;
   color: #fff;
 
@@ -97,6 +98,15 @@
 
 .controlGroupSeek {
   flex: 1;
+
+  @media only screen and (max-width: 660px) {
+    margin: 10px;
+    grid-area: 2 / 1 / 2 / 3;
+  }
+}
+
+.controlGroupVolume {
+  margin-left: auto;
 }
 
 .control {


### PR DESCRIPTION
スマホなどの表示領域の幅が狭い場合にaudio playerが2段になるように変更しました


<img width="509" alt="tofu-ninjin-player" src="https://user-images.githubusercontent.com/16757772/40982666-c6c60e3a-6918-11e8-8019-96b82c0178ab.png">
